### PR TITLE
PP-2676 Backfill script for performance platform

### DIFF
--- a/backfill.py
+++ b/backfill.py
@@ -7,11 +7,15 @@ def daterange(start_date, end_date):
         yield start_date + timedelta(n)
 
 parser = argparse.ArgumentParser(description='Backfill data in pay-performance-platform')
-parser.add_argument('--context', required=True)
-parser.add_argument('--start', required=True)
-parser.add_argument('--end', required=True)
+parser.add_argument('--context', required=True, help="Either 'test' to send data to test endpoint, or 'payments' to send to real endpoint")
+parser.add_argument('--start', required=True, help='Inclusive start date in format Y-m-d')
+parser.add_argument('--end', required=True, help='Inclusive end date in format Y-m-d')
 
 args = parser.parse_args()
+
+if args.context not in ['test', 'payments']:
+	raise Exception('context must be either "test" or "payments"')
+
 print 'Backfilling with context ' + args.context + ' for dates ' + args.start + ' to ' + args.end
 
 start = datetime.strptime(args.start + ' 23:59:59', "%Y-%m-%d %H:%M:%S")
@@ -20,4 +24,3 @@ end = datetime.strptime(args.end + ' 23:59:59', "%Y-%m-%d %H:%M:%S")
 for date in daterange(start, end):
 	print 'Backfilling ' + date.isoformat()
 	ppp.lambda_handler({'time': date.isoformat()}, args.context)
-

--- a/backfill.py
+++ b/backfill.py
@@ -1,0 +1,23 @@
+import pay_performance_platform as ppp
+import argparse
+from datetime import datetime, date, timedelta
+
+def daterange(start_date, end_date):
+    for n in range(int ((end_date - start_date).days) + 1):
+        yield start_date + timedelta(n)
+
+parser = argparse.ArgumentParser(description='Backfill data in pay-performance-platform')
+parser.add_argument('--context', required=True)
+parser.add_argument('--start', required=True)
+parser.add_argument('--end', required=True)
+
+args = parser.parse_args()
+print 'Backfilling with context ' + args.context + ' for dates ' + args.start + ' to ' + args.end
+
+start = datetime.strptime(args.start + ' 23:59:59', "%Y-%m-%d %H:%M:%S")
+end = datetime.strptime(args.end + ' 23:59:59', "%Y-%m-%d %H:%M:%S")
+
+for date in daterange(start, end):
+	print 'Backfilling ' + date.isoformat()
+	ppp.lambda_handler({'time': date.isoformat()}, args.context)
+

--- a/pay_performance_platform.py
+++ b/pay_performance_platform.py
@@ -9,10 +9,11 @@ from base64 import b64decode
 from datetime import timedelta
 from datetime import tzinfo
 from iso8601utils import parsers
+from string import Template
 
 logging.basicConfig(level=logging.INFO)
 
-URL = 'https://www.performance.service.gov.uk/data/govuk-pay/payments'
+URL = Template('https://www.performance.service.gov.uk/data/govuk-pay/$context')
 
 
 class SimpleUtc(tzinfo):
@@ -64,7 +65,7 @@ def generate_payload(
             }]
 
 
-def lambda_handler(event, context):
+def lambda_handler(event, context='payments'):
 
     dataset_bearer_token = os.getenv('DATASET_BEARER_TOKEN', '')
     sumo_access_id = os.getenv('SUMO_ACCESS_ID', '')
@@ -102,7 +103,7 @@ def lambda_handler(event, context):
         sumo.average_amount_paid())
 
     print payload
-    resp = requests.post(URL, json=payload, headers=headers)
+    resp = requests.post(URL.substitute(context=context), json=payload, headers=headers)
 
     if resp.status_code != 200:
         # This means something went wrong.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jsontree==0.4.3
 requests==2.14.2
 sumologic_sdk==0.1.7
 pytz==2013d
+boto3==1.4.7


### PR DESCRIPTION
Sometimes the Lambda to update pay performance platform
metrics fails (eg.most recently because some necessary credentials
were revoked). In these circumstances it is necessary to
backfill the missing data.

This script provides an easy means to do that.

To upload data to the test endpoint you can do:
`SUMO_ACCESS_ID=<SUMO_ACCESS_ID> SUMO_ACCESS_KEY=<SUMO_ACCESS_KEY> DATASET_BEARER_TOKEN=<DATA_BEARER_TOKEN> ENCRYPTED=<ENCRYPTED> python backfill.py --context test --start '2017-9-15' --end '2017-9-15'`

To upload data to the actual for realz endpoint do:
`SUMO_ACCESS_ID=<SUMO_ACCESS_ID> SUMO_ACCESS_KEY=<SUMO_ACCESS_KEY> DATASET_BEARER_TOKEN=<DATA_BEARER_TOKEN> ENCRYPTED=<ENCRYPTED> python backfill.py --context payments --start '2017-9-15' --end '2017-9-15'`

The start and end dates are both inclusive ie. to upload data for
only 15 Sep 2017 you should set `--start '2017-9-15' --end '2017-9-15'`